### PR TITLE
maa: import mvsfunc

### DIFF
--- a/fvsfunc.py
+++ b/fvsfunc.py
@@ -1054,6 +1054,11 @@ Works on any bitdepth
 """
 def maa(src, mask=None, chroma=None, ss=None, aa=None, aac=None, show=None):
 
+    try:
+        import mvsfunc as mvf
+    except ImportError:
+        raise ImportError('maa: mvsfunc not found. Download it here: https://github.com/HomeOfVapourSynthEvolution/mvsfunc')
+
     def SangNomAA(src, ss=2.0, aa=48, aac=None):
         ss_w = round(src.width * ss / 4) * 4
         ss_h = round(src.height * ss / 4) * 4


### PR DESCRIPTION
Fixes this error, guess there was some refactoring and you forgot to import in the function.
```
  File "/usr/lib/python3.8/site-packages/fvsfunc.py", line 1110, in maa
NameError: name 'mvf' is not defined
```